### PR TITLE
Add nicer shell prompt

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 2.0
 shards:
   linenoise:
     git: https://github.com/apainintheneck/crystal-linenoise.git
-    version: 0.3.0
+    version: 0.4.0
 

--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 2.0
 shards:
   linenoise:
     git: https://github.com/apainintheneck/crystal-linenoise.git
-    version: 0.1.0
+    version: 0.3.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -7,7 +7,7 @@ authors:
 dependencies:
   linenoise:
     github: apainintheneck/crystal-linenoise
-    version: ~> 0.1.0
+    version: 0.3.0
 
 targets:
   gitsh:

--- a/shard.yml
+++ b/shard.yml
@@ -7,7 +7,7 @@ authors:
 dependencies:
   linenoise:
     github: apainintheneck/crystal-linenoise
-    version: 0.3.0
+    version: 0.4.0
 
 targets:
   gitsh:

--- a/src/git.cr
+++ b/src/git.cr
@@ -54,7 +54,7 @@ module Git
     staged_count = 0_u32
     unstaged_count = 0_u32
 
-    buffer.to_s.lines.each do |line|
+    buffer.rewind.each_line do |line|
       staged_count += 1 if ('A'..'Z').covers?(line[0])
       unstaged_count += 1 if ('A'..'Z').covers?(line[1])
     end

--- a/src/git.cr
+++ b/src/git.cr
@@ -41,6 +41,30 @@ module Git
     branch
   end
 
+  # Get the counts of uncommitted changes for the shell prompt.
+  def self.uncommitted_changes : NamedTuple(staged_count: UInt32, unstaged_count: UInt32)
+    buffer = IO::Memory.new
+
+    Process.run(
+      command: executable_path,
+      args: %w[status --porcelain],
+      output: buffer,
+    )
+
+    staged_count = 0_u32
+    unstaged_count = 0_u32
+
+    buffer.to_s.lines.each do |line|
+      staged_count += 1 if ('A'..'Z').covers?(line[0])
+      unstaged_count += 1 if ('A'..'Z').covers?(line[1])
+    end
+
+    {
+      staged_count: staged_count,
+      unstaged_count: unstaged_count,
+    }
+  end
+
   @@commands : Array(String) = begin
     buffer = IO::Memory.new(capacity: 2048)
 
@@ -67,8 +91,9 @@ module Git
     Process.run(
       command: executable_path,
       args: args,
-      output: STDOUT,
-      error: STDERR,
+      output: :inherit,
+      error: :inherit,
+      input: :inherit,
     )
   end
 end

--- a/src/main.cr
+++ b/src/main.cr
@@ -15,8 +15,49 @@ puts <<-WELCOME
 #############################################################
 WELCOME
 
+def build_prompt(branch : String? = nil, unstaged_changes : UInt32 = 0, staged_changes : UInt32 = 0) : String
+  String.build do |str|
+    str << "gitsh".colorize(:light_cyan).mode(:bold)
+    if branch
+      str << " (" << branch.colorize(:magenta).mode(:bold) << "|"
+
+      if unstaged_changes.zero? && staged_changes.zero?
+        str << "✔".colorize(:green).mode(:bold)
+      end
+
+      if staged_changes.positive?
+        Colorize.with.yellow.surround(str) do
+          str << "●" << staged_changes
+        end
+      end
+
+      if unstaged_changes.positive?
+        Colorize.with.blue.surround(str) do
+          str << "+" << unstaged_changes
+        end
+      end
+
+      str << ")"
+    end
+    str << "> "
+  end
+end
+
+DEFAULT_PROMPT = build_prompt
+
 loop do
-  line = Linenoise.prompt("gitsh> ").try(&.strip)
+  if Git.repo?
+    changes = Git.uncommitted_changes
+    prompt_str = build_prompt(
+      branch: Git.current_branch,
+      unstaged_changes: changes[:unstaged_count],
+      staged_changes: changes[:staged_count],
+    )
+  else
+    prompt_str = DEFAULT_PROMPT
+  end
+
+  line = Linenoise.prompt(prompt_str).try(&.strip)
   break if line.nil?
 
   args = Process.parse_arguments(line)

--- a/src/main.cr
+++ b/src/main.cr
@@ -1,4 +1,5 @@
 require "./git"
+require "./prompt"
 require "linenoise"
 require "process"
 
@@ -15,49 +16,8 @@ puts <<-WELCOME
 #############################################################
 WELCOME
 
-def build_prompt(branch : String? = nil, unstaged_changes : UInt32 = 0, staged_changes : UInt32 = 0) : String
-  String.build do |str|
-    str << "gitsh".colorize(:light_cyan).mode(:bold)
-    if branch
-      str << " (" << branch.colorize(:magenta).mode(:bold) << "|"
-
-      if unstaged_changes.zero? && staged_changes.zero?
-        str << "✔".colorize(:green).mode(:bold)
-      end
-
-      if staged_changes.positive?
-        Colorize.with.yellow.surround(str) do
-          str << "●" << staged_changes
-        end
-      end
-
-      if unstaged_changes.positive?
-        Colorize.with.blue.surround(str) do
-          str << "+" << unstaged_changes
-        end
-      end
-
-      str << ")"
-    end
-    str << "> "
-  end
-end
-
-DEFAULT_PROMPT = build_prompt
-
 loop do
-  if Git.repo?
-    changes = Git.uncommitted_changes
-    prompt_str = build_prompt(
-      branch: Git.current_branch,
-      unstaged_changes: changes[:unstaged_count],
-      staged_changes: changes[:staged_count],
-    )
-  else
-    prompt_str = DEFAULT_PROMPT
-  end
-
-  line = Linenoise.prompt(prompt_str).try(&.strip)
+  line = Linenoise.prompt(Prompt.string).try(&.strip)
   break if line.nil?
 
   args = Process.parse_arguments(line)

--- a/src/prompt.cr
+++ b/src/prompt.cr
@@ -1,0 +1,50 @@
+require "./git"
+
+module Prompt
+  def self.string : String
+    if Git.repo?
+      changes = Git.uncommitted_changes
+      build(
+        branch: Git.current_branch,
+        unstaged_changes: changes[:unstaged_count],
+        staged_changes: changes[:staged_count],
+      )
+    else
+      default
+    end
+  end
+
+  @@default = ">"
+
+  def self.default : String
+    @@default ||= build
+  end
+
+  def self.build(branch : String? = nil, unstaged_changes : UInt32 = 0, staged_changes : UInt32 = 0) : String
+    String.build do |str|
+      str << "gitsh".colorize(:light_cyan).mode(:bold)
+      if branch
+        str << "(" << branch.colorize(:magenta).mode(:bold) << "|"
+
+        if unstaged_changes.zero? && staged_changes.zero?
+          str << "✔".colorize(:green).mode(:bold)
+        end
+
+        if staged_changes.positive?
+          Colorize.with.yellow.surround(str) do
+            str << "●" << staged_changes
+          end
+        end
+
+        if unstaged_changes.positive?
+          Colorize.with.blue.surround(str) do
+            str << "+" << unstaged_changes
+          end
+        end
+
+        str << ")"
+      end
+      str << "> "
+    end
+  end
+end


### PR DESCRIPTION
This adds color, branch, uncommited and commited changes to the shell prompt. It's essentially a complete copy of one of the default Fish shell prompts.