### PR TITLE
prompt: add tests and refactor module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: main
+  pull_request:
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install Crystal
+        uses: oprypin/install-crystal@v1
+        with:
+          crystal: latest
+
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: shards install
+
+      - name: Run linter
+        run: crystal tool format --check
+
+      - name: Run specs
+        run: crystal spec

--- a/spec/gitsh_spec.cr
+++ b/spec/gitsh_spec.cr
@@ -1,9 +1,0 @@
-require "./spec_helper"
-
-describe Gitsh do
-  # TODO: Write tests
-
-  it "works" do
-    false.should eq(true)
-  end
-end

--- a/spec/prompt_spec.cr
+++ b/spec/prompt_spec.cr
@@ -38,7 +38,7 @@ describe Prompt do
             # Commit one file
             FileUtils.touch "file1"
             Test.quiet_system("git add file1")
-            system("git commit -m 'first'")
+            system("git commit -m 'first' --author='Test <test@test.com>'")
             # One unstaged file change
             File.write "file1", "text"
 

--- a/spec/prompt_spec.cr
+++ b/spec/prompt_spec.cr
@@ -38,7 +38,7 @@ describe Prompt do
             # Commit one file
             FileUtils.touch "file1"
             Test.quiet_system("git add file1")
-            system("git commit -m 'first' --author='Test <test@test.com>'")
+            Test.quiet_system("git commit -m 'first'")
             # One unstaged file change
             File.write "file1", "text"
 

--- a/spec/prompt_spec.cr
+++ b/spec/prompt_spec.cr
@@ -2,8 +2,7 @@ require "./spec_helper"
 require "../src/prompt.cr"
 
 GITSH    = "gitsh".colorize(:light_cyan).mode(:bold)
-HEAD     = "HEAD".colorize(:magenta).mode(:bold)
-MASTER   = "master".colorize(:magenta).mode(:bold)
+BRANCH   = "main".colorize(:magenta).mode(:bold)
 CHECK    = "✔".colorize(:green).mode(:bold)
 STAGED   = "●2".colorize(:yellow)
 UNSTAGED = "+1".colorize(:blue)
@@ -14,7 +13,7 @@ describe Prompt do
       context "with no changes" do
         it "returns expected prompt" do
           TestDir.with_git_repo do
-            Prompt.string.should eq "#{GITSH}(#{HEAD}|#{CHECK})> "
+            Prompt.string.should eq "#{GITSH}(#{BRANCH}|#{CHECK})> "
           end
         end
       end
@@ -27,7 +26,7 @@ describe Prompt do
             FileUtils.touch "file2"
             Test.quiet_system("git add file1 file2")
 
-            Prompt.string.should eq "#{GITSH}(#{HEAD}|#{STAGED})> "
+            Prompt.string.should eq "#{GITSH}(#{BRANCH}|#{STAGED})> "
           end
         end
       end
@@ -42,7 +41,7 @@ describe Prompt do
             # One unstaged file change
             File.write "file1", "text"
 
-            Prompt.string.should eq "#{GITSH}(#{MASTER}|#{UNSTAGED})> "
+            Prompt.string.should eq "#{GITSH}(#{BRANCH}|#{UNSTAGED})> "
           end
         end
       end
@@ -57,7 +56,7 @@ describe Prompt do
             # One unstaged file change
             File.write "file1", "text"
 
-            Prompt.string.should eq "#{GITSH}(#{HEAD}|#{STAGED}#{UNSTAGED})> "
+            Prompt.string.should eq "#{GITSH}(#{BRANCH}|#{STAGED}#{UNSTAGED})> "
           end
         end
       end

--- a/spec/prompt_spec.cr
+++ b/spec/prompt_spec.cr
@@ -38,7 +38,7 @@ describe Prompt do
             # Commit one file
             FileUtils.touch "file1"
             Test.quiet_system("git add file1")
-            Test.quiet_system("git commit -m 'first'")
+            system("git commit -m 'first'")
             # One unstaged file change
             File.write "file1", "text"
 

--- a/spec/prompt_spec.cr
+++ b/spec/prompt_spec.cr
@@ -1,0 +1,74 @@
+require "./spec_helper"
+require "../src/prompt.cr"
+
+GITSH    = "gitsh".colorize(:light_cyan).mode(:bold)
+HEAD     = "HEAD".colorize(:magenta).mode(:bold)
+MASTER   = "master".colorize(:magenta).mode(:bold)
+CHECK    = "✔".colorize(:green).mode(:bold)
+STAGED   = "●2".colorize(:yellow)
+UNSTAGED = "+1".colorize(:blue)
+
+describe Prompt do
+  describe ".string" do
+    context "with git repo" do
+      context "with no changes" do
+        it "returns expected prompt" do
+          TestDir.with_git_repo do
+            Prompt.string.should eq "#{GITSH}(#{HEAD}|#{CHECK})> "
+          end
+        end
+      end
+
+      context "with 2 staged changes" do
+        it "returns expected prompt" do
+          TestDir.with_git_repo do
+            # Two staged file changes
+            FileUtils.touch "file1"
+            FileUtils.touch "file2"
+            Test.quiet_system("git add file1 file2")
+
+            Prompt.string.should eq "#{GITSH}(#{HEAD}|#{STAGED})> "
+          end
+        end
+      end
+
+      context "with 1 unstaged change" do
+        it "returns expected prompt" do
+          TestDir.with_git_repo do
+            # Commit one file
+            FileUtils.touch "file1"
+            Test.quiet_system("git add file1")
+            Test.quiet_system("git commit -m 'first'")
+            # One unstaged file change
+            File.write "file1", "text"
+
+            Prompt.string.should eq "#{GITSH}(#{MASTER}|#{UNSTAGED})> "
+          end
+        end
+      end
+
+      context "with 2 staged changes and 1 unstaged change" do
+        it "returns expected prompt" do
+          TestDir.with_git_repo do
+            # Two staged file changes
+            FileUtils.touch "file1"
+            FileUtils.touch "file2"
+            Test.quiet_system("git add file1 file2")
+            # One unstaged file change
+            File.write "file1", "text"
+
+            Prompt.string.should eq "#{GITSH}(#{HEAD}|#{STAGED}#{UNSTAGED})> "
+          end
+        end
+      end
+    end
+
+    context "without git repo" do
+      it "returns default prompt string" do
+        TestDir.without_git_repo do
+          Prompt.string.should eq "#{GITSH}> "
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,7 +7,7 @@ require "process"
 %w[AUTHOR COMMITTER].each do |role|
   ENV["GIT_#{role}_NAME"] = "gitsh tests"
   ENV["GIT_#{role}_EMAIL"] = "gitsh-tests@localhost"
-  ENV["GIT_#{role}_DATE"]  = "Sun Jan 22 19:59:13 2017 +0000"
+  ENV["GIT_#{role}_DATE"] = "Sun Jan 22 19:59:13 2017 +0000"
 end
 
 module Test

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -46,7 +46,11 @@ module TestDir
   def self.with_git_repo(&block)
     in_temp_directory do
       Test.quiet_system("git init")
+      # Add a commit to be able to set the branch name.
+      FileUtils.touch ".keep"
+      Test.quiet_system("git add .keep && git commit -m 'init'")
       Test.quiet_system("git branch -m main")
+
       block.call
     end
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,6 +2,14 @@ require "spec"
 require "file_utils"
 require "process"
 
+# Copied from `Library/Homebrew/dev-cmd/tests.rb`.
+# This prevents git repo set up errors.
+%w[AUTHOR COMMITTER].each do |role|
+  ENV["GIT_#{role}_NAME"] = "gitsh tests"
+  ENV["GIT_#{role}_EMAIL"] = "gitsh-tests@localhost"
+  ENV["GIT_#{role}_DATE"]  = "Sun Jan 22 19:59:13 2017 +0000"
+end
+
 module Test
   # Runs a system command without printing to stdout or stderr.
   def self.quiet_system(command)
@@ -38,6 +46,7 @@ module TestDir
   def self.with_git_repo(&block)
     in_temp_directory do
       Test.quiet_system("git init")
+      Test.quiet_system("git branch -m main")
       block.call
     end
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,44 @@
 require "spec"
-require "../src/gitsh"
+require "file_utils"
+require "process"
+
+module Test
+  # Runs a system command without printing to stdout or stderr.
+  def self.quiet_system(command)
+    Process.run(
+      command: command,
+      shell: true,
+    )
+  end
+end
+
+module TestDir
+  private def self.in_temp_directory(&block)
+    old_dir = Dir.current
+    tmp_dir = File.tempname
+
+    begin
+      Dir.mkdir tmp_dir
+      Dir.cd tmp_dir
+      block.call
+    ensure
+      Dir.cd old_dir
+      FileUtils.rm_rf tmp_dir
+    end
+  end
+
+  # Creates a temporary directory without a git repo.
+  # The given block is then run in this directory.
+  def self.without_git_repo(&block)
+    in_temp_directory(&block)
+  end
+
+  # Creates a temporary directory and initializes a git repo in it.
+  # The given block is then run in this directory.
+  def self.with_git_repo(&block)
+    in_temp_directory do
+      Test.quiet_system("git init")
+      block.call
+    end
+  end
+end

--- a/src/git.cr
+++ b/src/git.cr
@@ -60,7 +60,7 @@ module Git
     end
 
     {
-      staged_count: staged_count,
+      staged_count:   staged_count,
       unstaged_count: unstaged_count,
     }
   end

--- a/src/prompt.cr
+++ b/src/prompt.cr
@@ -1,6 +1,8 @@
 require "./git"
 
 module Prompt
+  @@default : String?
+
   def self.string : String
     if Git.repo?
       changes = Git.uncommitted_changes
@@ -10,17 +12,11 @@ module Prompt
         staged_changes: changes[:staged_count],
       )
     else
-      default
+      @@default ||= build
     end
   end
 
-  @@default : String = build
-
-  def self.default : String
-    @@default
-  end
-
-  def self.build(branch : String? = nil, unstaged_changes : UInt32 = 0, staged_changes : UInt32 = 0) : String
+  private def self.build(branch : String? = nil, unstaged_changes : UInt32 = 0, staged_changes : UInt32 = 0) : String
     String.build do |str|
       str << "gitsh".colorize(:light_cyan).mode(:bold)
       if branch


### PR DESCRIPTION
This adds some specs for the shell prompt module which was a bit more involved than I originally though it would be. The main thing is that I had to set up a temporary directory and do some git commands. I also had to make sure not to print any intermediate shell commands to stdout or stderr.

It would be good to set up CI before merging this in to make sure to run the test suite and linter.