### PR TITLE
Update prompt with exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         run: crystal tool format --check
 
       - name: Run specs
-        run: crystal spec
+        run: crystal spec --order random

--- a/spec/prompt_spec.cr
+++ b/spec/prompt_spec.cr
@@ -1,71 +1,139 @@
 require "./spec_helper"
 require "../src/prompt.cr"
 
-GITSH    = "gitsh".colorize(:light_cyan).mode(:bold)
-BRANCH   = "main".colorize(:magenta).mode(:bold)
-CHECK    = "✔".colorize(:green).mode(:bold)
-STAGED   = "●2".colorize(:yellow)
-UNSTAGED = "+1".colorize(:blue)
+GITSH     = "gitsh".colorize(:light_cyan).mode(:bold)
+BRANCH    = "main".colorize(:magenta).mode(:bold)
+CHECK     = "✔".colorize(:green).mode(:bold)
+STAGED    = "●2".colorize(:yellow)
+UNSTAGED  = "+1".colorize(:blue)
+SUCCESS   = 0
+FAILURE   = 127
+EXIT_CODE = "[127]".colorize(:red)
 
 describe Prompt do
   describe ".string" do
-    context "with git repo" do
-      context "with no changes" do
-        it "returns expected prompt" do
-          TestDir.with_git_repo do
-            Prompt.string.should eq "#{GITSH}(#{BRANCH}|#{CHECK})> "
+    context "with zero exit code" do
+      context "with git repo" do
+        context "with no changes" do
+          it "returns expected prompt" do
+            TestDir.with_git_repo do
+              Prompt.string(SUCCESS).should eq "#{GITSH}(#{BRANCH}|#{CHECK})> "
+            end
+          end
+        end
+
+        context "with 2 staged changes" do
+          it "returns expected prompt" do
+            TestDir.with_git_repo do
+              # Two staged file changes
+              FileUtils.touch "file1"
+              FileUtils.touch "file2"
+              Test.quiet_system("git add file1 file2")
+
+              Prompt.string(SUCCESS).should eq "#{GITSH}(#{BRANCH}|#{STAGED})> "
+            end
+          end
+        end
+
+        context "with 1 unstaged change" do
+          it "returns expected prompt" do
+            TestDir.with_git_repo do
+              # Commit one file
+              FileUtils.touch "file1"
+              Test.quiet_system("git add file1")
+              Test.quiet_system("git commit -m 'first'")
+              # One unstaged file change
+              File.write "file1", "text"
+
+              Prompt.string(SUCCESS).should eq "#{GITSH}(#{BRANCH}|#{UNSTAGED})> "
+            end
+          end
+        end
+
+        context "with 2 staged changes and 1 unstaged change" do
+          it "returns expected prompt" do
+            TestDir.with_git_repo do
+              # Two staged file changes
+              FileUtils.touch "file1"
+              FileUtils.touch "file2"
+              Test.quiet_system("git add file1 file2")
+              # One unstaged file change
+              File.write "file1", "text"
+
+              Prompt.string(SUCCESS).should eq "#{GITSH}(#{BRANCH}|#{STAGED}#{UNSTAGED})> "
+            end
           end
         end
       end
 
-      context "with 2 staged changes" do
-        it "returns expected prompt" do
-          TestDir.with_git_repo do
-            # Two staged file changes
-            FileUtils.touch "file1"
-            FileUtils.touch "file2"
-            Test.quiet_system("git add file1 file2")
-
-            Prompt.string.should eq "#{GITSH}(#{BRANCH}|#{STAGED})> "
-          end
-        end
-      end
-
-      context "with 1 unstaged change" do
-        it "returns expected prompt" do
-          TestDir.with_git_repo do
-            # Commit one file
-            FileUtils.touch "file1"
-            Test.quiet_system("git add file1")
-            Test.quiet_system("git commit -m 'first'")
-            # One unstaged file change
-            File.write "file1", "text"
-
-            Prompt.string.should eq "#{GITSH}(#{BRANCH}|#{UNSTAGED})> "
-          end
-        end
-      end
-
-      context "with 2 staged changes and 1 unstaged change" do
-        it "returns expected prompt" do
-          TestDir.with_git_repo do
-            # Two staged file changes
-            FileUtils.touch "file1"
-            FileUtils.touch "file2"
-            Test.quiet_system("git add file1 file2")
-            # One unstaged file change
-            File.write "file1", "text"
-
-            Prompt.string.should eq "#{GITSH}(#{BRANCH}|#{STAGED}#{UNSTAGED})> "
+      context "without git repo" do
+        it "returns default prompt string" do
+          TestDir.without_git_repo do
+            Prompt.string(SUCCESS).should eq "#{GITSH}> "
           end
         end
       end
     end
 
-    context "without git repo" do
-      it "returns default prompt string" do
-        TestDir.without_git_repo do
-          Prompt.string.should eq "#{GITSH}> "
+    context "with non-zero exit code" do
+      context "with git repo" do
+        context "with no changes" do
+          it "returns expected prompt" do
+            TestDir.with_git_repo do
+              Prompt.string(FAILURE).should eq "#{GITSH}(#{BRANCH}|#{CHECK})#{EXIT_CODE}> "
+            end
+          end
+        end
+
+        context "with 2 staged changes" do
+          it "returns expected prompt" do
+            TestDir.with_git_repo do
+              # Two staged file changes
+              FileUtils.touch "file1"
+              FileUtils.touch "file2"
+              Test.quiet_system("git add file1 file2")
+
+              Prompt.string(FAILURE).should eq "#{GITSH}(#{BRANCH}|#{STAGED})#{EXIT_CODE}> "
+            end
+          end
+        end
+
+        context "with 1 unstaged change" do
+          it "returns expected prompt" do
+            TestDir.with_git_repo do
+              # Commit one file
+              FileUtils.touch "file1"
+              Test.quiet_system("git add file1")
+              Test.quiet_system("git commit -m 'first'")
+              # One unstaged file change
+              File.write "file1", "text"
+
+              Prompt.string(FAILURE).should eq "#{GITSH}(#{BRANCH}|#{UNSTAGED})#{EXIT_CODE}> "
+            end
+          end
+        end
+
+        context "with 2 staged changes and 1 unstaged change" do
+          it "returns expected prompt" do
+            TestDir.with_git_repo do
+              # Two staged file changes
+              FileUtils.touch "file1"
+              FileUtils.touch "file2"
+              Test.quiet_system("git add file1 file2")
+              # One unstaged file change
+              File.write "file1", "text"
+
+              Prompt.string(FAILURE).should eq "#{GITSH}(#{BRANCH}|#{STAGED}#{UNSTAGED})#{EXIT_CODE}> "
+            end
+          end
+        end
+      end
+
+      context "without git repo" do
+        it "returns default prompt string" do
+          TestDir.without_git_repo do
+            Prompt.string(FAILURE).should eq "#{GITSH}#{EXIT_CODE}> "
+          end
         end
       end
     end

--- a/spec/prompt_spec.cr
+++ b/spec/prompt_spec.cr
@@ -6,7 +6,7 @@ BRANCH    = "main".colorize(:magenta).mode(:bold)
 CHECK     = "✔".colorize(:green).mode(:bold)
 STAGED    = "●2".colorize(:yellow)
 UNSTAGED  = "+1".colorize(:blue)
-SUCCESS   = 0
+SUCCESS   =   0
 FAILURE   = 127
 EXIT_CODE = "[127]".colorize(:red)
 

--- a/src/git.cr
+++ b/src/git.cr
@@ -41,8 +41,10 @@ module Git
     branch
   end
 
+  record Changes, staged_count : UInt32, unstaged_count : UInt32
+
   # Get the counts of uncommitted changes for the shell prompt.
-  def self.uncommitted_changes : NamedTuple(staged_count: UInt32, unstaged_count: UInt32)
+  def self.uncommitted_changes : Changes
     buffer = IO::Memory.new
 
     Process.run(
@@ -59,10 +61,7 @@ module Git
       unstaged_count += 1 if ('A'..'Z').covers?(line[1])
     end
 
-    {
-      staged_count:   staged_count,
-      unstaged_count: unstaged_count,
-    }
+    Changes.new staged_count: staged_count, unstaged_count: unstaged_count
   end
 
   @@commands : Array(String) = begin

--- a/src/prompt.cr
+++ b/src/prompt.cr
@@ -3,18 +3,19 @@ require "./git"
 module Prompt
   @@default : String?
 
-  def self.string : String
+  def self.string(exit_code : Int32 = 0) : String
     if Git.repo?
       build(
+        status: exit_code,
         branch: Git.current_branch,
         changes: Git.uncommitted_changes,
       )
     else
-      @@default ||= build
+      build(status: exit_code)
     end
   end
 
-  private def self.build(branch : String? = nil, changes : Git::Changes? = nil) : String
+  private def self.build(status : Int32, branch : String? = nil, changes : Git::Changes? = nil) : String
     String.build do |str|
       str << "gitsh".colorize(:light_cyan).mode(:bold)
 
@@ -42,6 +43,12 @@ module Prompt
         end
 
         str << ")"
+      end
+
+      if status.positive?
+        Colorize.with.red.surround(str) do
+          str << "[" << status << "]"
+        end
       end
 
       str << "> "

--- a/src/prompt.cr
+++ b/src/prompt.cr
@@ -5,41 +5,45 @@ module Prompt
 
   def self.string : String
     if Git.repo?
-      changes = Git.uncommitted_changes
       build(
         branch: Git.current_branch,
-        unstaged_changes: changes[:unstaged_count],
-        staged_changes: changes[:staged_count],
+        changes: Git.uncommitted_changes,
       )
     else
       @@default ||= build
     end
   end
 
-  private def self.build(branch : String? = nil, unstaged_changes : UInt32 = 0, staged_changes : UInt32 = 0) : String
+  private def self.build(branch : String? = nil, changes : Git::Changes? = nil) : String
     String.build do |str|
       str << "gitsh".colorize(:light_cyan).mode(:bold)
+
       if branch
-        str << "(" << branch.colorize(:magenta).mode(:bold) << "|"
+        str << "(" << branch.colorize(:magenta).mode(:bold)
 
-        if unstaged_changes.zero? && staged_changes.zero?
-          str << "✔".colorize(:green).mode(:bold)
-        end
+        if changes
+          str << "|"
 
-        if staged_changes.positive?
-          Colorize.with.yellow.surround(str) do
-            str << "●" << staged_changes
+          if changes.unstaged_count.zero? && changes.staged_count.zero?
+            str << "✔".colorize(:green).mode(:bold)
           end
-        end
 
-        if unstaged_changes.positive?
-          Colorize.with.blue.surround(str) do
-            str << "+" << unstaged_changes
+          if changes.staged_count.positive?
+            Colorize.with.yellow.surround(str) do
+              str << "●" << changes.staged_count
+            end
+          end
+
+          if changes.unstaged_count.positive?
+            Colorize.with.blue.surround(str) do
+              str << "+" << changes.unstaged_count
+            end
           end
         end
 
         str << ")"
       end
+
       str << "> "
     end
   end

--- a/src/repl.cr
+++ b/src/repl.cr
@@ -18,9 +18,11 @@ module REPL
 
     puts "# Welcome to gitsh!"
 
+    exit_code = 0
+
     # Run the shell REPL in a loop.
     loop do
-      line = Linenoise.prompt(Prompt.string).try(&.strip)
+      line = Linenoise.prompt(Prompt.string(exit_code)).try(&.strip)
       break if line.nil?
 
       args = Process.parse_arguments(line)
@@ -35,7 +37,7 @@ module REPL
         break
       end
 
-      Git.run(args)
+      exit_code = Git.run(args).exit_code
 
       # Save the current input line to the shell history.
       Linenoise.add_history(line)


### PR DESCRIPTION
The shell prompt will now show the exit code of the previous command if it failed with a non-zero exit code.

```
# Welcome to gitsh!
gitsh(update-prompt-with-exit-code|✔)> slkdfjsd
git: 'slkdfjsd' is not a git command. See 'git --help'.
gitsh(update-prompt-with-exit-code|✔)[1]> 
```