### PR TITLE
Add support for multiple commands in one line of input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [0.2.0] - 2024-05-04
+
+### Added
+
+- Command line options and help
+- Support for logical shell operators (&&, || and ;)
+
+## [0.1.0] - 2024-04-25
+
+### Added
+
+- A nicer shell prompt
+- Support for shell history
+- Support for basic shell completions

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # gitsh
 
-A simple shell wrapper for Git that provides completions, history and doesn't require you to add the `git` prefix to each command.
-
-Based on this awk abomination: https://gist.github.com/apainintheneck/ddc87043a645e87f2d9e02b69be155b6
+A simple shell wrapper for Git that provides logical shell operators, completions, history and doesn't require you to add the `git` prefix to each command.
 
 ## Installation
 
@@ -31,6 +29,11 @@ Based on this awk abomination: https://gist.github.com/apainintheneck/ddc87043a6
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+
+## Inspired By
+- [zbg](https://github.com/chshersh/zbg) : `zbg` (short for Zero Bullshit Git) is a CLI tool for using `git` efficiently.
+- [gitsh.awk](https://gist.github.com/apainintheneck/ddc87043a645e87f2d9e02b69be155b6) : A simplistic `gawk` based `git` shell.
+- [fish-shell](https://github.com/fish-shell/fish-shell) : The `fish` shell has a great set of built-in integrations with `git`.
 
 ## Contributors
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: gitsh
-version: 0.1.0
+version: 0.2.0
 
 authors:
   - Kevin Robell <apainintheneck@gmail.com>

--- a/spec/executor_spec.cr
+++ b/spec/executor_spec.cr
@@ -1,0 +1,207 @@
+require "./spec_helper"
+require "../src/executor"
+
+describe Executor do
+  describe ".execute_line" do
+    # SUCCESS
+    context "with a single command" do
+      it "executes a command with the git prefix" do
+        out_buffer = IO::Memory.new
+        err_buffer = IO::Memory.new
+
+        Executor.execute_line(line: "git help", output: out_buffer, error: err_buffer).should eq(
+          Executor::Result.new(Executor::Result::Type::Success, 0)
+        )
+
+        out_buffer.to_s.should start_with("usage: git")
+        err_buffer.to_s.should be_empty
+      end
+
+      it "executes a command without the git prefix" do
+        out_buffer = IO::Memory.new
+        err_buffer = IO::Memory.new
+
+        Executor.execute_line(line: "help", output: out_buffer, error: err_buffer).should eq(
+          Executor::Result.new(Executor::Result::Type::Success, 0)
+        )
+
+        out_buffer.to_s.should start_with("usage: git")
+        err_buffer.to_s.should be_empty
+      end
+
+      it "executes an unknown command and returns a non-zero exit code" do
+        out_buffer = IO::Memory.new
+        err_buffer = IO::Memory.new
+
+        Executor.execute_line(line: "unknown command", output: out_buffer, error: err_buffer).should eq(
+          Executor::Result.new(Executor::Result::Type::Success, 1)
+        )
+
+        out_buffer.to_s.should be_empty
+        err_buffer.to_s.should eq("git: 'unknown' is not a git command. See 'git --help'.\n")
+      end
+    end
+
+    context "with two commands" do
+      context "with '&&'" do
+        it "executes the second command when the first succeeds" do
+          out_buffer = IO::Memory.new
+          err_buffer = IO::Memory.new
+
+          Executor.execute_line(line: "help && unknown command", output: out_buffer, error: err_buffer).should eq(
+            Executor::Result.new(Executor::Result::Type::Success, 1)
+          )
+
+          out_buffer.to_s.should start_with("usage: git")
+          err_buffer.to_s.should eq("git: 'unknown' is not a git command. See 'git --help'.\n")
+        end
+
+        it "skips the second command when the first fails" do
+          out_buffer = IO::Memory.new
+          err_buffer = IO::Memory.new
+
+          Executor.execute_line(line: "unknown command && help", output: out_buffer, error: err_buffer).should eq(
+            Executor::Result.new(Executor::Result::Type::Success, 1)
+          )
+
+          out_buffer.to_s.should be_empty
+          err_buffer.to_s.should eq("git: 'unknown' is not a git command. See 'git --help'.\n")
+        end
+      end
+
+      context "with '||'" do
+        it "skips the second command when the first succeeds" do
+          out_buffer = IO::Memory.new
+          err_buffer = IO::Memory.new
+
+          Executor.execute_line(line: "help || unknown command", output: out_buffer, error: err_buffer).should eq(
+            Executor::Result.new(Executor::Result::Type::Success, 0)
+          )
+
+          out_buffer.to_s.should start_with("usage: git")
+          err_buffer.to_s.should be_empty
+        end
+
+        it "executes the second command when the first fails" do
+          out_buffer = IO::Memory.new
+          err_buffer = IO::Memory.new
+
+          Executor.execute_line(line: "unknown command || help", output: out_buffer, error: err_buffer).should eq(
+            Executor::Result.new(Executor::Result::Type::Success, 0)
+          )
+
+          out_buffer.to_s.should start_with("usage: git")
+          err_buffer.to_s.should eq("git: 'unknown' is not a git command. See 'git --help'.\n")
+        end
+      end
+
+      context "with semicolon" do
+        it "executes the second command when the first succeeds" do
+          out_buffer = IO::Memory.new
+          err_buffer = IO::Memory.new
+
+          Executor.execute_line(line: "help; unknown command", output: out_buffer, error: err_buffer).should eq(
+            Executor::Result.new(Executor::Result::Type::Success, 1)
+          )
+
+          out_buffer.to_s.should start_with("usage: git")
+          err_buffer.to_s.should eq("git: 'unknown' is not a git command. See 'git --help'.\n")
+        end
+
+        it "executes the second command when the first fails" do
+          out_buffer = IO::Memory.new
+          err_buffer = IO::Memory.new
+
+          Executor.execute_line(line: "unknown command; help", output: out_buffer, error: err_buffer).should eq(
+            Executor::Result.new(Executor::Result::Type::Success, 0)
+          )
+
+          out_buffer.to_s.should start_with("usage: git")
+          err_buffer.to_s.should eq("git: 'unknown' is not a git command. See 'git --help'.\n")
+        end
+      end
+    end
+
+    context "with chained commands" do
+      it "when it succeeds it skips everything after || until ;" do
+        out_buffer = IO::Memory.new
+        err_buffer = IO::Memory.new
+        line = "help || help || help && help; unknown command"
+
+        Executor.execute_line(line: line, output: out_buffer, error: err_buffer).should eq(
+          Executor::Result.new(Executor::Result::Type::Success, 1)
+        )
+
+        out_buffer.to_s.scan(/usage: git/).size.should eq(1)
+        err_buffer.to_s.should eq("git: 'unknown' is not a git command. See 'git --help'.\n")
+      end
+
+      it "when it fails it skips everything after && until ||" do
+        out_buffer = IO::Memory.new
+        err_buffer = IO::Memory.new
+        line = "unknown command && help && help || version && help; version"
+
+        Executor.execute_line(line: line, output: out_buffer, error: err_buffer).should eq(
+          Executor::Result.new(Executor::Result::Type::Success, 0)
+        )
+
+        out_buffer.to_s.scan(/usage: git/).size.should eq(1)
+        out_buffer.to_s.scan(/git version/).size.should eq(2)
+        err_buffer.to_s.should eq("git: 'unknown' is not a git command. See 'git --help'.\n")
+      end
+
+      it "when it fails it skips everything after && until ;" do
+        out_buffer = IO::Memory.new
+        err_buffer = IO::Memory.new
+        line = "unknown command && version && version && version; version"
+
+        Executor.execute_line(line: line, output: out_buffer, error: err_buffer).should eq(
+          Executor::Result.new(Executor::Result::Type::Success, 0)
+        )
+
+        out_buffer.to_s.scan(/git version/).size.should eq(1)
+        err_buffer.to_s.should eq("git: 'unknown' is not a git command. See 'git --help'.\n")
+      end
+    end
+
+    # EXIT
+    it "exits successfully" do
+      %w[exit quit].each do |command|
+        out_buffer = IO::Memory.new
+        err_buffer = IO::Memory.new
+
+        Executor.execute_line(line: command, output: out_buffer, error: err_buffer).should eq(
+          Executor::Result.new(Executor::Result::Type::Exit, 0)
+        )
+
+        out_buffer.to_s.should eq("Have a nice day!\n")
+        err_buffer.to_s.should be_empty
+      end
+    end
+
+    # FAILURE
+    it "fails when there is a tokenizer error" do
+      out_buffer = IO::Memory.new
+      err_buffer = IO::Memory.new
+
+      Executor.execute_line(line: "first second 'third fourth", output: out_buffer, error: err_buffer).should eq(
+        Executor::Result.new(Executor::Result::Type::Failure, 127)
+      )
+
+      out_buffer.to_s.should be_empty
+      err_buffer.to_s.should end_with("Missing matching single-quote to close string\n")
+    end
+
+    it "fails when there is a parser error" do
+      out_buffer = IO::Memory.new
+      err_buffer = IO::Memory.new
+
+      Executor.execute_line(line: "first && && fourth", output: out_buffer, error: err_buffer).should eq(
+        Executor::Result.new(Executor::Result::Type::Failure, 127)
+      )
+
+      out_buffer.to_s.should be_empty
+      err_buffer.to_s.should end_with("Expected a string after '&&' but got '&&' instead\n")
+    end
+  end
+end

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -1,0 +1,102 @@
+require "./spec_helper"
+require "../src/parser"
+
+class CommandFactory
+  @commands = [] of Command
+
+  def and(arguments : Array(String)) : self
+    @commands << Command.new(Command::Action::And, arguments)
+    self
+  end
+
+  def or(arguments : Array(String)) : self
+    @commands << Command.new(Command::Action::Or, arguments)
+    self
+  end
+
+  def end(arguments : Array(String)) : self
+    @commands << Command.new(Command::Action::End, arguments)
+    self
+  end
+
+  def to_a : Array(Command)
+    @commands
+  end
+end
+
+describe Parser do
+  it "parses a single command" do
+    Parser.parse("checkout auto_update_tap").should eq(
+      CommandFactory.new.end(%w[checkout auto_update_tap]).to_a
+    )
+  end
+
+  it "parses multiple commands joined with an action" do
+    [
+      {
+        %{add --all; commit -m "tmp"},
+        CommandFactory.new.end(%w[add --all]).end(%w[commit -m tmp]).to_a,
+      },
+      {
+        %{add --all || commit -m "tmp"},
+        CommandFactory.new.end(%w[add --all]).or(%w[commit -m tmp]).to_a,
+      },
+      {
+        %{add --all && commit -m "tmp"},
+        CommandFactory.new.end(%w[add --all]).and(%w[commit -m tmp]).to_a,
+      },
+    ].each do |line, parse_result|
+      Parser.parse(line).should eq(parse_result)
+    end
+  end
+
+  it "parses a long series of commands" do
+    parse_result = CommandFactory.new
+      .end(%w[add ex.js])
+      .and(%w[add ex.rb])
+      .end(%w[git diff])
+      .end(%w[git commit -m commit])
+      .to_a
+
+    Parser.parse("add ex.js && add ex.rb; git diff; git commit -m 'commit'").should eq(parse_result)
+  end
+
+  it "parses and ignores a trailing semicolon" do
+    Parser.parse(%{grep 'rescue GitHub::API';}).should eq(
+      CommandFactory.new.end(["grep", "rescue GitHub::API"]).to_a
+    )
+  end
+
+  it "raises an error when there is an action to start a line" do
+    %w[&& || ;].each do |action|
+      line = [action, "second", "third"].join(" ")
+      error_message = "Expected a string to start the line but got '#{action}' instead"
+
+      expect_raises(Parser::Exception, error_message) do
+        Parser.parse(line)
+      end
+    end
+  end
+
+  it "raises an error when there are two actions in a row in the middle of a line" do
+    %w[&& || ;].repeated_combinations(2).each do |combo|
+      line = ["first", *combo, "last"].join(" ")
+      error_message = "Expected a string after '#{combo.first}' but got '#{combo.last}' instead"
+
+      expect_raises(Parser::Exception, error_message) do
+        Parser.parse(line)
+      end
+    end
+  end
+
+  it "raises an error when there is a && or || action to end a line" do
+    %w[&& ||].each do |action|
+      line = ["first", "second", action].join(" ")
+      error_message = "Expected a string or a semicolon to end the line but got '#{action}' instead"
+
+      expect_raises(Parser::Exception, error_message) do
+        Parser.parse(line)
+      end
+    end
+  end
+end

--- a/spec/prompt_spec.cr
+++ b/spec/prompt_spec.cr
@@ -28,7 +28,7 @@ describe Prompt do
               # Two staged file changes
               FileUtils.touch "file1"
               FileUtils.touch "file2"
-              Test.quiet_system("git add file1 file2")
+              TestShell.quiet_system("git add file1 file2")
 
               Prompt.string(SUCCESS).should eq "#{GITSH}(#{BRANCH}|#{STAGED})> "
             end
@@ -40,8 +40,8 @@ describe Prompt do
             TestDir.with_git_repo do
               # Commit one file
               FileUtils.touch "file1"
-              Test.quiet_system("git add file1")
-              Test.quiet_system("git commit -m 'first'")
+              TestShell.quiet_system("git add file1")
+              TestShell.quiet_system("git commit -m 'first'")
               # One unstaged file change
               File.write "file1", "text"
 
@@ -56,7 +56,7 @@ describe Prompt do
               # Two staged file changes
               FileUtils.touch "file1"
               FileUtils.touch "file2"
-              Test.quiet_system("git add file1 file2")
+              TestShell.quiet_system("git add file1 file2")
               # One unstaged file change
               File.write "file1", "text"
 
@@ -91,7 +91,7 @@ describe Prompt do
               # Two staged file changes
               FileUtils.touch "file1"
               FileUtils.touch "file2"
-              Test.quiet_system("git add file1 file2")
+              TestShell.quiet_system("git add file1 file2")
 
               Prompt.string(FAILURE).should eq "#{GITSH}(#{BRANCH}|#{STAGED})#{EXIT_CODE}> "
             end
@@ -103,8 +103,8 @@ describe Prompt do
             TestDir.with_git_repo do
               # Commit one file
               FileUtils.touch "file1"
-              Test.quiet_system("git add file1")
-              Test.quiet_system("git commit -m 'first'")
+              TestShell.quiet_system("git add file1")
+              TestShell.quiet_system("git commit -m 'first'")
               # One unstaged file change
               File.write "file1", "text"
 
@@ -119,7 +119,7 @@ describe Prompt do
               # Two staged file changes
               FileUtils.touch "file1"
               FileUtils.touch "file2"
-              Test.quiet_system("git add file1 file2")
+              TestShell.quiet_system("git add file1 file2")
               # One unstaged file change
               File.write "file1", "text"
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -10,7 +10,7 @@ require "process"
   ENV["GIT_#{role}_DATE"] = "Sun Jan 22 19:59:13 2017 +0000"
 end
 
-module Test
+module TestShell
   # Runs a system command without printing to stdout or stderr.
   def self.quiet_system(command)
     Process.run(
@@ -45,11 +45,11 @@ module TestDir
   # The given block is then run in this directory.
   def self.with_git_repo(&block)
     in_temp_directory do
-      Test.quiet_system("git init")
+      TestShell.quiet_system("git init")
       # Add a commit to be able to set the branch name.
       FileUtils.touch ".keep"
-      Test.quiet_system("git add .keep && git commit -m 'init'")
-      Test.quiet_system("git branch -m main")
+      TestShell.quiet_system("git add .keep && git commit -m 'init'")
+      TestShell.quiet_system("git branch -m main")
 
       block.call
     end

--- a/spec/tokenizer_spec.cr
+++ b/spec/tokenizer_spec.cr
@@ -1,0 +1,147 @@
+require "./spec_helper"
+require "../src/tokenizer.cr"
+
+class TokenFactory
+  @tokens = [] of Tokenizer::Token
+
+  def and : self
+    @tokens << new_token(Tokenizer::Token::Type::And, "&&")
+    self
+  end
+
+  def or : self
+    @tokens << new_token(Tokenizer::Token::Type::Or, "||")
+    self
+  end
+
+  def end : self
+    @tokens << new_token(Tokenizer::Token::Type::End, ";")
+    self
+  end
+
+  def string(content : String) : self
+    @tokens << new_token(Tokenizer::Token::Type::String, content)
+    self
+  end
+
+  def to_a
+    @tokens
+  end
+
+  # Note: Token position is not super important during tests and we only test for equality
+  # based on token type and content for that reason.
+  private def new_token(type : Tokenizer::Token::Type, content : String) : Tokenizer::Token
+    Tokenizer::Token.new(type: type, content: content, start_position: 0, end_position: 0)
+  end
+end
+
+describe Tokenizer do
+  describe ".tokenize" do
+    it "tokenizes blanks lines" do
+      ["", "   ", "\t", "\n", "  \t \n"].each do |line|
+        Tokenizer.tokenize(line).empty?.should be_true
+      end
+    end
+
+    it "tokenizes commands without arguments" do
+      %w{diff log branch commit}.each do |line|
+        Tokenizer.tokenize(line).should eq(TokenFactory.new.string(line).to_a)
+      end
+    end
+
+    it "tokenizes single-quoted strings" do
+      [
+        {
+          %{grep 'type : Tokenizer'},
+          TokenFactory.new.string("grep").string("type : Tokenizer").to_a,
+        },
+        {
+          %{grep 'describe ".tokenize" do'  },
+          TokenFactory.new.string("grep").string(%{describe ".tokenize" do}).to_a,
+        },
+        {
+          %{add -- '*.js'},
+          TokenFactory.new.string("add").string("--").string("*.js").to_a,
+        },
+        {
+          %{ log --committer='Lawrence Kraft'},
+          TokenFactory.new.string("log").string("--committer=Lawrence Kraft").to_a,
+        },
+      ].each do |line, tokens|
+        Tokenizer.tokenize(line).should eq(tokens)
+      end
+    end
+
+    it "tokenizes double-quoted strings" do
+      [
+        {
+          %{grep   " type : Tokenizer"},
+          TokenFactory.new.string("grep").string(" type : Tokenizer").to_a,
+        },
+        {
+          %{log   --grep   "'exit' or 'quit'"},
+          TokenFactory.new.string("log").string("--grep").string("'exit' or 'quit'").to_a,
+        },
+        {
+          %{  add -- "*.js"},
+          TokenFactory.new.string("add").string("--").string("*.js").to_a,
+        },
+        {
+          %{log --author="One Punch Man"},
+          TokenFactory.new.string("log").string("--author=One Punch Man").to_a,
+        },
+      ].each do |line, tokens|
+        Tokenizer.tokenize(line).should eq(tokens)
+      end
+    end
+
+    it "raises a syntax error when a matching closing quote is missing" do
+      [
+        %{grep "skdfsdklfj},
+        %{commit -m 'slkdfjsdklfjds},
+        %{log --author="sdkfsdlkj'dsfkjds'},
+        %{branch -D 'sdkfsdlkj"dsfkjds"},
+      ].each do |line|
+        expect_raises(Tokenizer::SyntaxException, /Missing matching (?:single|double)-quote/) do
+          Tokenizer.tokenize(line)
+        end
+      end
+    end
+
+    {% for name, action in {"and" => "&&", "or" => "||", "end" => ";"} %}
+      it "tokenizes lines with '{{action.id}}'" do
+        [
+          "first {{action.id}} second",
+          "first{{action.id}} second",
+          "first {{action.id}}second",
+          "first{{action.id}}second",
+        ].each do |line|
+          Tokenizer.tokenize(line).should eq(
+            TokenFactory.new.string("first").{{name.id}}.string("second").to_a
+          )
+        end
+      end
+
+      it "tokenizes strings with '{{action.id}}'" do
+        Tokenizer.tokenize("commit -m 'Fixed thing one {{action.id}} thing two'").should eq(
+          TokenFactory.new.string("commit").string("-m").string("Fixed thing one {{action.id}} thing two").to_a
+        )
+      end
+    {% end %}
+
+    it "tokenizes strings with multiple actions" do
+      [
+        {
+          "one && two; three || four",
+          TokenFactory.new.string("one").and.string("two").end.string("three").or.string("four").to_a,
+        },
+        {
+          "&&   &&&&;||",
+          TokenFactory.new.and.and.and.end.or.to_a,
+        },
+      ].each do |line, tokens|
+        Tokenizer.tokenize(line).should eq(tokens)
+      end
+    end
+  end
+end

--- a/src/command.cr
+++ b/src/command.cr
@@ -1,3 +1,11 @@
+# Represents a single shell command and action pair.
+# - Action: The logical action between the previous command and this one.
+# - Command: The shell command to run as an array of strings.
+#
+# There are three possible actions:
+# 1. '&&' - Requires the previous command to exit successfully.
+# 2. '||' - Requires the previous command to fail.
+# 3. ';'  - Runs no matter what happened with the previous command.
 class Command
   def_equals @action, @arguments # for testing
 

--- a/src/command.cr
+++ b/src/command.cr
@@ -1,0 +1,15 @@
+class Command
+  def_equals @action, @arguments # for testing
+
+  enum Action
+    And # Run this command if the previous one succeeded.
+    Or  # Run this command if the previous one failed.
+    End # Run this command regardless of the previous command.
+  end
+
+  getter action : Action
+  property arguments : Array(String)
+
+  def initialize(@action, @arguments = [] of String)
+  end
+end

--- a/src/executor.cr
+++ b/src/executor.cr
@@ -1,0 +1,49 @@
+require "./git"
+require "./parser"
+
+module Executor
+  record Result, type : Result::Type, exit_code : Int32 do
+    enum Type
+      Success # No major problems running commands.
+      Failure # Syntax or parsing errors before running commands.
+      Exit    # The user has decided to close the program.
+    end
+  end
+
+  def self.execute_line(line : String, output : IO = STDOUT, error : IO = STDERR) : Result
+    exit_code = 0
+    skip_to_end = false
+
+    Parser.parse(line).each do |command|
+      case command.action
+      in .and?
+        next if skip_to_end
+        next unless exit_code.zero?
+      in .or?
+        skip_to_end = true if exit_code.zero?
+        next if skip_to_end
+      in .end?
+        skip_to_end = false
+      end
+
+      case command.arguments.first
+      when "git"
+        command.arguments.shift
+      when "exit", "quit"
+        output.puts "Have a nice day!"
+        return Result.new type: Result::Type::Exit, exit_code: 0
+      end
+
+      exit_code = Git.run(
+        args: command.arguments,
+        output: output,
+        error: error,
+      ).exit_code
+    end
+
+    return Result.new type: Result::Type::Success, exit_code: exit_code
+  rescue ex : Parser::Exception | Tokenizer::SyntaxException
+    error.puts ex.message
+    return Result.new type: Result::Type::Failure, exit_code: 127
+  end
+end

--- a/src/executor.cr
+++ b/src/executor.cr
@@ -1,6 +1,8 @@
 require "./git"
 require "./parser"
 
+# Executes a series of commands based on their associated actions.
+# See `Command` for more information.
 module Executor
   record Result, type : Result::Type, exit_code : Int32 do
     enum Type
@@ -10,25 +12,35 @@ module Executor
     end
   end
 
+  # Run a series of commands based on their actions and return the result of the last command.
   def self.execute_line(line : String, output : IO = STDOUT, error : IO = STDERR) : Result
     exit_code = 0
+
+    # We skip to the next `end` action when a successful command is followed by the `or` action.
+    # For example: `first || second || third && fourth; fifth`
+    #
+    # In this case, only the `first` and `fifth` commands would get run.
+    # The rest of the commands would get skipped.
     skip_to_end = false
 
     Parser.parse(line).each do |command|
       case command.action
       in .and?
         next if skip_to_end
+        # Skip the command if the previous one failed.
         next unless exit_code.zero?
       in .or?
+        # Skip to the end if the previous command succeeded.
         skip_to_end = true if exit_code.zero?
         next if skip_to_end
       in .end?
+        # Always run the command after the `end` action.
         skip_to_end = false
       end
 
       case command.arguments.first
       when "git"
-        command.arguments.shift
+        command.arguments.shift # ignore unnecessary 'git' prefix
       when "exit", "quit"
         output.puts "Have a nice day!"
         return Result.new type: Result::Type::Exit, exit_code: 0

--- a/src/git.cr
+++ b/src/git.cr
@@ -86,12 +86,12 @@ module Git
   end
 
   # Run Git with the given arguments.
-  def self.run(args : Array(String)) : Process::Status
+  def self.run(args : Array(String), output : IO = STDOUT, error : IO = STDERR) : Process::Status
     Process.run(
       command: executable_path,
       args: args,
-      output: :inherit,
-      error: :inherit,
+      output: output,
+      error: error,
       input: :inherit,
     )
   end

--- a/src/main.cr
+++ b/src/main.cr
@@ -12,6 +12,11 @@ OptionParser.parse do |parser|
   Options:
   BANNER
 
+  # TODO: Add the following commands
+  # --check-config : Validate the config file commands
+  # --config-path  : Path to the config file
+  # --reset-config : Reset the config file to its default state
+
   parser.on("--history-path", "Path to the history file") do
     puts REPL::HISTORY_FILE
     exit

--- a/src/main.cr
+++ b/src/main.cr
@@ -22,6 +22,11 @@ OptionParser.parse do |parser|
     exit
   end
 
+  parser.on("-v", "--version", "Show the current version") do
+    puts "0.2.0"
+    exit
+  end
+
   parser.on("-h", "--help", "Show this help page") do
     puts parser
     exit

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -1,0 +1,37 @@
+require "./command"
+require "./tokenizer"
+
+module Parser
+  class Exception < Exception; end
+
+  def self.parse(line : String) : Array(Command)
+    command_list = [] of Command
+    tokens = Tokenizer.tokenize(line)
+    return command_list if tokens.empty?
+
+    if tokens.first.type.string?
+      command_list << Command.new(action: Command::Action::End, arguments: [tokens.first.content])
+    else
+      raise Exception.new(message: "#{tokens.first.location}: Expected a string to start the line but got '#{tokens.first.content}' instead")
+    end
+
+    if tokens.last.type.and? || tokens.last.type.or?
+      raise Exception.new(message: "#{tokens.last.location}: Expected a string or a semicolon to end the line but got '#{tokens.last.content}' instead")
+    end
+
+    tokens.each_cons_pair do |prev_token, token|
+      case {prev_token.type, token.type}
+      when {_, .string?}
+        command_list.last.arguments << token.content
+      when {.string?, _}
+        command_list << Command.new(action: token.type.to_action!)
+      else
+        raise Exception.new(message: "#{token.location}: Expected a string after '#{prev_token.content}' but got '#{token.content}' instead")
+      end
+    end
+
+    command_list.pop if command_list.last.action.end? && command_list.last.arguments.empty?
+
+    command_list
+  end
+end

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -4,6 +4,7 @@ require "./tokenizer"
 module Parser
   class Exception < Exception; end
 
+  # Parse the line of input into a series of commands.
   def self.parse(line : String) : Array(Command)
     command_list = [] of Command
     tokens = Tokenizer.tokenize(line)
@@ -21,15 +22,16 @@ module Parser
 
     tokens.each_cons_pair do |prev_token, token|
       case {prev_token.type, token.type}
-      when {_, .string?}
+      when {_, .string?} # Token is a string.
         command_list.last.arguments << token.content
-      when {.string?, _}
+      when {.string?, _} # Token is an action.
         command_list << Command.new(action: token.type.to_action!)
       else
         raise Exception.new(message: "#{token.location}: Expected a string after '#{prev_token.content}' but got '#{token.content}' instead")
       end
     end
 
+    # Remove any trailing semicolons from the command list.
     command_list.pop if command_list.last.action.end? && command_list.last.arguments.empty?
 
     command_list

--- a/src/repl.cr
+++ b/src/repl.cr
@@ -41,6 +41,7 @@ module REPL
         # Don't save lines with syntax or parsing errors to the shell history.
         nil
       in .exit?
+        # The user entered 'exit' or 'quit'.
         return
       end
 

--- a/src/repl.cr
+++ b/src/repl.cr
@@ -1,3 +1,5 @@
+require "./command"
+require "./executor"
 require "./git"
 require "./prompt"
 require "linenoise"
@@ -7,6 +9,8 @@ module REPL
   HISTORY_FILE = File.expand_path("~/.gitsh_history", home: true)
 
   def self.run!
+    Linenoise.set_multiline(true)
+
     # Set up shell history.
     Linenoise.load_history(HISTORY_FILE)
     Linenoise.max_history(500)
@@ -24,24 +28,23 @@ module REPL
     loop do
       line = Linenoise.prompt(Prompt.string(exit_code)).try(&.strip)
       break if line.nil?
+      next if line.blank?
 
-      args = Process.parse_arguments(line)
-      next if args.empty?
+      result = Executor.execute_line(line)
 
-      case args.first
-      when "git"
-        puts "Warn: 'git' is added automatically before all commands"
-        args.shift
-      when "exit", "quit"
-        puts "Have a nice day!"
-        break
+      case result.type
+      in .success?
+        # Save the current input line to the shell history.
+        Linenoise.add_history(line)
+        Linenoise.save_history(HISTORY_FILE)
+      in .failure?
+        # Don't save lines with syntax or parsing errors to the shell history.
+        nil
+      in .exit?
+        return
       end
 
-      exit_code = Git.run(args).exit_code
-
-      # Save the current input line to the shell history.
-      Linenoise.add_history(line)
-      Linenoise.save_history(HISTORY_FILE)
+      exit_code = result.exit_code
     end
   end
 end

--- a/src/tokenizer.cr
+++ b/src/tokenizer.cr
@@ -36,6 +36,7 @@ module Tokenizer
     end
   end
 
+  # Turn a line of input into a series of action and string tokens.
   def self.tokenize(line : String) : Array(Token)
     tokens = [] of Token
     scanner = StringScanner.new(line)
@@ -43,30 +44,30 @@ module Tokenizer
     while !scanner.eos?
       start_position = scanner.offset
 
-      if scanner.skip(/\s+/)
+      if scanner.skip(/\s+/) # whitespace
         next
-      elsif scanner.scan(/&{2}/)
+      elsif scanner.scan(/&{2}/) # and (&&)
         tokens << Token.new(
           type: Token::Type::And,
           content: "&&",
           start_position: start_position,
           end_position: scanner.offset,
         )
-      elsif scanner.scan(/[|]{2}/)
+      elsif scanner.scan(/[|]{2}/) # or (||)
         tokens << Token.new(
           type: Token::Type::Or,
           content: "||",
           start_position: start_position,
           end_position: scanner.offset,
         )
-      elsif scanner.scan(/;/)
+      elsif scanner.scan(/;/) # end (;)
         tokens << Token.new(
           type: Token::Type::End,
           content: ";",
           start_position: start_position,
           end_position: scanner.offset,
         )
-      else
+      else # quoted or unquoted string
         tokens << Token.new(
           type: Token::Type::String,
           content: scan_string_token(scanner),
@@ -79,6 +80,7 @@ module Tokenizer
     tokens
   end
 
+  # Scan a quoted or unquoted string. Only quoted strings can contain whitespace.
   private def self.scan_string_token(scanner : StringScanner) : String
     String.build do |builder|
       while !scanner.eos? && !scanner.check(/&{2}|[|]{2}|;|\s/)
@@ -114,6 +116,7 @@ module Tokenizer
           when "\""
             raise SyntaxException.new(message: "#{scanner.offset}: Missing matching double-quote to close string")
           else
+            # This should be unreachable but we provide sensible error message anyway.
             raise SyntaxException.new(message: "#{scanner.offset}: Unknown syntax error")
           end
         end

--- a/src/tokenizer.cr
+++ b/src/tokenizer.cr
@@ -1,0 +1,123 @@
+require "./command"
+require "string_scanner"
+
+module Tokenizer
+  class SyntaxException < Exception; end
+
+  record Token, type : Token::Type, content : String, start_position : Int32, end_position : Int32 do
+    def_equals @type, @content # for testing
+
+    enum Type
+      String # "string"
+      And    # &&
+      Or     # ||
+      End    # ;
+
+      def to_action : Command::Action?
+        case self
+        in .and?
+          Command::Action::And
+        in .or?
+          Command::Action::Or
+        in .end?
+          Command::Action::End
+        in .string?
+          nil
+        end
+      end
+
+      def to_action! : Command::Action
+        to_action.not_nil!
+      end
+    end
+
+    def location : String
+      "#{start_position}:#{end_position}"
+    end
+  end
+
+  def self.tokenize(line : String) : Array(Token)
+    tokens = [] of Token
+    scanner = StringScanner.new(line)
+
+    while !scanner.eos?
+      start_position = scanner.offset
+
+      if scanner.skip(/\s+/)
+        next
+      elsif scanner.scan(/&{2}/)
+        tokens << Token.new(
+          type: Token::Type::And,
+          content: "&&",
+          start_position: start_position,
+          end_position: scanner.offset,
+        )
+      elsif scanner.scan(/[|]{2}/)
+        tokens << Token.new(
+          type: Token::Type::Or,
+          content: "||",
+          start_position: start_position,
+          end_position: scanner.offset,
+        )
+      elsif scanner.scan(/;/)
+        tokens << Token.new(
+          type: Token::Type::End,
+          content: ";",
+          start_position: start_position,
+          end_position: scanner.offset,
+        )
+      else
+        tokens << Token.new(
+          type: Token::Type::String,
+          content: scan_string_token(scanner),
+          start_position: start_position,
+          end_position: scanner.offset,
+        )
+      end
+    end
+
+    tokens
+  end
+
+  private def self.scan_string_token(scanner : StringScanner) : String
+    String.build do |builder|
+      while !scanner.eos? && !scanner.check(/&{2}|[|]{2}|;|\s/)
+        # a single ampersand or pipe character
+        str = scanner.scan(/[&|]/)
+
+        # TODO: Handle exempting quotes with the backslash character in strings.
+
+        # a single-quoted string (without the quotes)
+        str ||= if scanner.scan(/'([^']*)'/)
+                  scanner[1]
+                end
+
+        # a double-quoted string (without the quotes)
+        str ||= if scanner.scan(/"([^"]*)"/)
+                  scanner[1]
+                end
+
+        # everything else that is not:
+        # - an ampersand
+        # - a pipe character
+        # - a semicolon
+        # - a single or double quote
+        # - a whitespace character
+        str ||= scanner.scan(/[^&|;'"\s]+/)
+
+        if str
+          builder << str
+        else
+          case scanner.peek(1)
+          when "'"
+            raise SyntaxException.new(message: "#{scanner.offset}: Missing matching single-quote to close string")
+          when "\""
+            raise SyntaxException.new(message: "#{scanner.offset}: Missing matching double-quote to close string")
+          else
+            raise SyntaxException.new(message: "#{scanner.offset}: Unknown syntax error")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The goal here is to support the &&, || and ; shell operators to allow running multiple commands off of one line of input. This is a nice to have feature for the shell but will be especially useful when adding custom commands to a future config file.

- [x] add a tokenizer
- [x] add a parser
- [x] add a executor (to run the commands based on actions)
- [x] add tests
- [x] add documentation
- [x] update readme
- [x] add changelog
- [x] make new release

### Tokenizer

This will allow us to tokenizer lines of input that describe multiple commands separated by actions.

Example: `add --all && commit -m tmp`

The available actions are the &&, || and ; operators which function the same way you'd expect them to based on using a shell. There is also tokenization support for single and double-quoted strings though they are identical functionally (no string interpolation is supported for now).

### Parser

This will allow us to take the tokens and turn them into command-action pairs. The action specifies how the previous command should exit before the command is run. Sometimes the command will be skipped based on the previous commands exit code and the action.

Example: `add --all && commit -m tmp`

### Executor

This will take the list of command-action pairs from the parser and actually runs them according to the exit codes and actions. Some of the commands will be skipped based on the logical actions.

### REPL

This module handles getting lines of input from the REPL and calling the executor.

### Main

This module is the entry point of the program and includes some command line flags so that things can be more easily accessed. It also features the help page.